### PR TITLE
Handling of end of trace

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,3 +60,8 @@ jacoco.exec
 
 # SonarQube
 .sonar/
+
+# IDEA-specific
+.idea/
+*.iml
+out/

--- a/Core/src/ca/uqac/lif/cep/GroupProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/GroupProcessor.java
@@ -536,7 +536,7 @@ public class GroupProcessor extends Processor
 		
 		@Override
 		public void notifyEndOfTrace() throws PushableException {
-			notifyEndOfTrace();
+			m_pushable.notifyEndOfTrace();
 		}
 
 		@Override

--- a/Core/src/ca/uqac/lif/cep/GroupProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/GroupProcessor.java
@@ -533,6 +533,11 @@ public class GroupProcessor extends Processor
 		{
 			return push(o);
 		}
+		
+		@Override
+		public void notifyEndOfTrace() throws PushableException {
+			notifyEndOfTrace();
+		}
 
 		@Override
 		synchronized public Processor getProcessor()

--- a/Core/src/ca/uqac/lif/cep/Pushable.java
+++ b/Core/src/ca/uqac/lif/cep/Pushable.java
@@ -71,6 +71,9 @@ public interface Pushable
 	 */
 	public Pushable pushFast(Object o) throws PushableException;
 
+	
+	public void notifyEndOfTrace() throws PushableException;
+	
 	/**
 	 * Gets the processor instance this Pushable is linked to
 	 * @return The processor
@@ -182,6 +185,11 @@ public interface Pushable
 			throw new UnsupportedOperationException();
 		}
 
+		@Override
+		public void notifyEndOfTrace() throws PushableException {
+			throw new UnsupportedOperationException();
+		}
+		
 		@Override
 		public Processor getProcessor() 
 		{

--- a/Core/src/ca/uqac/lif/cep/PushableWrapper.java
+++ b/Core/src/ca/uqac/lif/cep/PushableWrapper.java
@@ -45,6 +45,11 @@ public class PushableWrapper implements Pushable
 	{
 		return m_pushable.pushFast(o);
 	}
+	
+	@Override
+	public void notifyEndOfTrace() throws PushableException {
+		m_pushable.notifyEndOfTrace();
+	}
 
 	@Override
 	public Processor getProcessor()

--- a/Core/src/ca/uqac/lif/cep/tmf/CountDecimate.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/CountDecimate.java
@@ -90,6 +90,7 @@ public class CountDecimate extends SingleProcessor
 		if (m_current == 0)
 		{
 			out = inputs;
+			m_lastInputs = null;
 		}
 		else if(m_shouldOutputLastInputsAnyway)
 		{
@@ -117,11 +118,11 @@ public class CountDecimate extends SingleProcessor
 	}
 
 	@Override
-	protected boolean onEndOfTrace(Queue<Object[]> outputs) throws ProcessorException {
-		if(!m_shouldOutputLastInputsAnyway || m_current == 1)
+	protected boolean onEndOfTrace(Queue<Object[]> outputs) throws ProcessorException
+	{
+		if(!m_shouldOutputLastInputsAnyway || m_lastInputs == null)
 			return super.onEndOfTrace(outputs);
 
-		m_outputCount++;
 		outputs.add(m_lastInputs);
 		m_lastInputs = null;
 

--- a/Core/src/ca/uqac/lif/cep/tmf/Faucet.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Faucet.java
@@ -104,7 +104,8 @@ public abstract class Faucet extends Processor
 		
 		@Override
 		public void notifyEndOfTrace() throws PushableException {
-			// TODO Auto-generated method stub
+			// TODO: should we add an onEndOfTace method to Faucet?
+			m_outputPushables[0].notifyEndOfTrace();
 		}
 
 		@Override

--- a/Core/src/ca/uqac/lif/cep/tmf/Faucet.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Faucet.java
@@ -101,6 +101,11 @@ public abstract class Faucet extends Processor
 		{
 			return push(o);
 		}
+		
+		@Override
+		public void notifyEndOfTrace() throws PushableException {
+			// TODO Auto-generated method stub
+		}
 
 		@Override
 		public Processor getProcessor() 

--- a/Core/src/ca/uqac/lif/cep/tmf/Multiplexer.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Multiplexer.java
@@ -17,6 +17,7 @@
  */
 package ca.uqac.lif.cep.tmf;
 
+import java.util.Arrays;
 import java.util.Iterator;
 
 import ca.uqac.lif.cep.Processor;
@@ -47,6 +48,15 @@ import ca.uqac.lif.cep.Pushable;
  */
 public class Multiplexer extends Processor
 {
+	/** 
+	 * Array containing for each PushableInput of the processor 
+	 * if it has been notified of the end of trace or not.
+	 * Used to determine if the Multiplexer should notify its 
+	 * PushableOutput of the end of trace or not
+	 */
+	private boolean[] m_havePushableInputsReachedEnd;
+	
+	
 	/**
 	 * Instantiates a multiplexer
 	 * @param in_arity The input arity of the multiplexer. This is the
@@ -55,6 +65,8 @@ public class Multiplexer extends Processor
 	public Multiplexer(int in_arity)
 	{
 		super(in_arity, 1);
+		m_havePushableInputsReachedEnd = new boolean[in_arity];
+		Arrays.fill(m_havePushableInputsReachedEnd, false);
 	}
 
 	@Override
@@ -282,8 +294,15 @@ public class Multiplexer extends Processor
 
 		@Override
 		public void notifyEndOfTrace() throws PushableException {
-			// TODO Auto-generated method stub
+			m_havePushableInputsReachedEnd[m_index] = true;
+						
+			for(boolean hasReachedEnd : m_havePushableInputsReachedEnd)
+			{
+				if(!hasReachedEnd)
+					return;
+			}
 			
+			m_outputPushables[0].notifyEndOfTrace();
 		}
 		
 		@Override

--- a/Core/src/ca/uqac/lif/cep/tmf/Multiplexer.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Multiplexer.java
@@ -281,6 +281,12 @@ public class Multiplexer extends Processor
 		}
 
 		@Override
+		public void notifyEndOfTrace() throws PushableException {
+			// TODO Auto-generated method stub
+			
+		}
+		
+		@Override
 		public Processor getProcessor()
 		{
 			return Multiplexer.this;

--- a/Core/src/ca/uqac/lif/cep/tmf/Pump.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Pump.java
@@ -97,6 +97,7 @@ public class Pump extends Processor implements Runnable
 				}
 			}
 		}
+		pushable.notifyEndOfTrace();
 	}
 
 	@Override

--- a/Core/src/ca/uqac/lif/cep/tmf/SmartFork.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/SmartFork.java
@@ -177,6 +177,12 @@ public final class SmartFork extends Processor
 			incrementClean();
 			return this;
 		}
+		
+		@Override
+		public void notifyEndOfTrace() throws PushableException {
+			// TODO Auto-generated method stub
+			
+		}
 
 		@Override
 		synchronized public Processor getProcessor()

--- a/Core/src/ca/uqac/lif/cep/tmf/SmartFork.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/SmartFork.java
@@ -180,8 +180,10 @@ public final class SmartFork extends Processor
 		
 		@Override
 		public void notifyEndOfTrace() throws PushableException {
-			// TODO Auto-generated method stub
-			
+			for (int i = 0; i < m_outputPushables.length; i++) 
+			{
+				m_outputPushables[i].notifyEndOfTrace();
+			}
 		}
 
 		@Override

--- a/Core/src/ca/uqac/lif/cep/tmf/Tank.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Tank.java
@@ -114,8 +114,8 @@ public class Tank extends SingleProcessor
 		
 		@Override
 		public void notifyEndOfTrace() throws PushableException {
-			// TODO Auto-generated method stub
-			
+			// TODO: to be verified
+			m_outputPushables[0].notifyEndOfTrace();
 		}
 
 		@Override

--- a/Core/src/ca/uqac/lif/cep/tmf/Tank.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Tank.java
@@ -111,6 +111,12 @@ public class Tank extends SingleProcessor
 		{
 			return push(o);
 		}
+		
+		@Override
+		public void notifyEndOfTrace() throws PushableException {
+			// TODO Auto-generated method stub
+			
+		}
 
 		@Override
 		public Processor getProcessor() 

--- a/CoreTest/src/ca/uqac/lif/cep/EndOfTraceTest.java
+++ b/CoreTest/src/ca/uqac/lif/cep/EndOfTraceTest.java
@@ -14,6 +14,8 @@ import ca.uqac.lif.cep.tmf.Pump;
 import ca.uqac.lif.cep.tmf.QueueSink;
 import ca.uqac.lif.cep.tmf.QueueSource;
 
+import javax.swing.*;
+
 public class EndOfTraceTest {
 	
 	private final static String END_OF_TRACE = "End of trace";
@@ -101,5 +103,37 @@ public class EndOfTraceTest {
 			assertEquals(i, (int) queue.remove());
 		
 		assertEquals(END_OF_TRACE, (String) queue.remove());		
+	}
+
+	@Test
+	public void testGroupProcessor() throws ConnectorException {
+		Passthrough
+				passthrough0 = new EndOfTracePassthrough(1),
+				passthrough1 = new EndOfTracePassthrough(1);
+		Connector.connect(passthrough0, passthrough1);
+
+		GroupProcessor groupProcessor = new GroupProcessor(1, 1);
+		groupProcessor.associateInput(0, passthrough0, 0);
+		groupProcessor.associateOutput(0, passthrough1, 0);
+
+
+		QueueSink sink = new QueueSink(1);
+		Connector.connect(groupProcessor, sink);
+
+		Pushable pushable = groupProcessor.getPushableInput(0);
+		Queue<Object> queueSink = sink.getQueue(0);
+
+		for(int i = 0; i < 10; i++)
+		{
+			pushable.push(i);
+			assertEquals(i, (int) queueSink.remove());
+		}
+
+		pushable.notifyEndOfTrace();
+		assertEquals(END_OF_TRACE, (String) queueSink.remove());
+
+
+
+
 	}
 }

--- a/CoreTest/src/ca/uqac/lif/cep/EndOfTraceTest.java
+++ b/CoreTest/src/ca/uqac/lif/cep/EndOfTraceTest.java
@@ -1,0 +1,61 @@
+package ca.uqac.lif.cep;
+
+import static org.junit.Assert.assertEquals;
+
+import java.net.ConnectException;
+import java.util.Arrays;
+import java.util.Queue;
+
+import org.junit.Test;
+
+import ca.uqac.lif.cep.Connector.ConnectorException;
+import ca.uqac.lif.cep.tmf.Passthrough;
+import ca.uqac.lif.cep.tmf.QueueSink;
+import ca.uqac.lif.cep.tmf.QueueSource;
+import ca.uqac.lif.cep.tmf.Sink;
+
+public class EndOfTraceTest {
+	
+	private final static String END_OF_TRACE = "End of trace";
+	
+	public class EndOfTracePassthrough extends Passthrough {
+		
+		
+		
+		public EndOfTracePassthrough(int i) {
+			super(i);
+		}
+
+		@Override
+		protected boolean onEndOfTrace(Object[] outputs) throws ProcessorException {
+			System.out.println(END_OF_TRACE);
+			Arrays.fill(outputs, END_OF_TRACE);
+			return true;
+		}
+	}
+	
+	
+	@Test
+	public void testEndOfTracePrinter() throws ConnectorException {
+		EndOfTracePassthrough endOfTracePassthrough = new EndOfTracePassthrough(1);
+		QueueSink sink = new QueueSink(1);
+		
+		Connector.connect(endOfTracePassthrough, sink);
+		
+		
+		Pushable pushable = endOfTracePassthrough.getPushableInput(0);
+		pushable.push(1);
+		pushable.push(2);
+		pushable.push(3);
+		pushable.notifyEndOfTrace();
+		
+		Queue<Object> queue = sink.getQueue(0);
+		assertEquals(1, (int) queue.remove());
+		assertEquals(2, (int) queue.remove());
+		assertEquals(3, (int) queue.remove());
+		assertEquals(END_OF_TRACE, (String) queue.remove());
+
+		
+	}
+
+}

--- a/CoreTest/src/ca/uqac/lif/cep/EndOfTraceTest.java
+++ b/CoreTest/src/ca/uqac/lif/cep/EndOfTraceTest.java
@@ -2,26 +2,23 @@ package ca.uqac.lif.cep;
 
 import static org.junit.Assert.assertEquals;
 
-import java.net.ConnectException;
 import java.util.Arrays;
 import java.util.Queue;
 
 import org.junit.Test;
 
 import ca.uqac.lif.cep.Connector.ConnectorException;
+import ca.uqac.lif.cep.tmf.Multiplexer;
 import ca.uqac.lif.cep.tmf.Passthrough;
+import ca.uqac.lif.cep.tmf.Pump;
 import ca.uqac.lif.cep.tmf.QueueSink;
 import ca.uqac.lif.cep.tmf.QueueSource;
-import ca.uqac.lif.cep.tmf.Sink;
 
 public class EndOfTraceTest {
 	
 	private final static String END_OF_TRACE = "End of trace";
 	
 	public class EndOfTracePassthrough extends Passthrough {
-		
-		
-		
 		public EndOfTracePassthrough(int i) {
 			super(i);
 		}
@@ -42,20 +39,67 @@ public class EndOfTraceTest {
 		
 		Connector.connect(endOfTracePassthrough, sink);
 		
-		
 		Pushable pushable = endOfTracePassthrough.getPushableInput(0);
-		pushable.push(1);
-		pushable.push(2);
-		pushable.push(3);
-		pushable.notifyEndOfTrace();
-		
 		Queue<Object> queue = sink.getQueue(0);
-		assertEquals(1, (int) queue.remove());
-		assertEquals(2, (int) queue.remove());
-		assertEquals(3, (int) queue.remove());
+		for(int i = 0; i < 10; i++) 
+		{
+			pushable.push(i);
+			assertEquals(i, (int) queue.remove());
+		}
+		pushable.notifyEndOfTrace();
 		assertEquals(END_OF_TRACE, (String) queue.remove());
-
+	}
+	
+	
+	@Test
+	public void testMultiplexer() throws ConnectorException {
+		Multiplexer multiplexer = new Multiplexer(2);
+		EndOfTracePassthrough endOfTracePassthrough = new EndOfTracePassthrough(1);
+		QueueSink sink = new QueueSink(1);
 		
+		Connector.connect(multiplexer, endOfTracePassthrough, sink);
+		
+		Pushable pushable0 = multiplexer.getPushableInput(0);
+		Pushable pushable1 = multiplexer.getPushableInput(1);
+		Queue<Object> queue = sink.getQueue(0);
+		
+		for(int i = 0; i < 10; i++)
+		{
+			if(i < 5)
+				pushable0.push(i);
+			else 
+				pushable0.notifyEndOfTrace();
+			
+			pushable1.push(i+100);
+			
+			if(i < 5)
+				assertEquals(i, (int) queue.remove());
+			assertEquals(i+100, (int) queue.remove());
+		}		
+		pushable1.notifyEndOfTrace();
+		assertEquals(END_OF_TRACE, (String) queue.remove());
 	}
 
+	
+	@Test
+	public void testPump() throws ConnectorException {
+		QueueSource source = new QueueSource();
+		Pump pump = new Pump();
+		Passthrough passthrough = new EndOfTracePassthrough(1);
+		QueueSink sink = new QueueSink(1);
+		
+		Connector.connect(source, pump, passthrough, sink);
+		
+		source.loop(false);
+		for(int i = 0; i < 10; i++)
+			source.addEvent(i);
+		
+		pump.run();
+		
+		Queue<Object> queue = sink.getQueue(0);
+		for(int i = 0; i < 10; i++) 
+			assertEquals(i, (int) queue.remove());
+		
+		assertEquals(END_OF_TRACE, (String) queue.remove());		
+	}
 }


### PR DESCRIPTION
Where there is no more event to be processed, a `Pushable` can be notified with the `Pushable.notifyEndOfTrace()` method.

Overview of changes :

- `Pump`
When there is no more element to pull (`pullable.hasNext() == false`), a `Pump` calls `notifyEndOfTrace()` on its pushable output.

- `SingleProcessor`
Since a front must be complete in order to be processed, as soon as one of its pushable inputs has been notified of the end of trace (EOT), `SingleProcessor.onEndOfTrace(Queue<Object[]> outputs)` is called. By default, the method does not output anything and returns false. The method can be override an must return `true` in order for the result to be output.

- `UniformProcessor`
Same as `SingleProcessor`.

- `GroupProcessor`
Once a pushable input/output of a group has been notified, it notifies the pushable of the associated processor.

- `Faucet`
Pushable can be notified of EOT, but should a Faucet implements an `onEndOfTrace()` method? i.e. could a faucet be expected to do something specific on EOT?

- `Multiplexer`
When an input pushable is notified of EOT, checks if all other inputs have been notified and iff they have, the pushable output is notified too.

- Other
Adapted `SmartFork`, `Tank`, `PushableWrapper` to EOT handling.
`TimeDecimate` and `CountDecimate` can now specify a mode in which the last input is output if it has not been output already by the "normal" behaviour/rate.

- Created tests in `EndOfTraceTest`




