### PR TITLE
Detect case when capturing group does not match any text

### DIFF
--- a/Core/src/ca/uqac/lif/cep/util/FindPattern.java
+++ b/Core/src/ca/uqac/lif/cep/util/FindPattern.java
@@ -102,28 +102,22 @@ public class FindPattern extends SynchronousProcessor
     int last_end = 0;
     while (mat.find())
     {
+      String matched;
       if (mat.groupCount() > 0)
       {
-        if (m_trim)
+        matched = mat.group(1);
+        if (matched == null)
         {
-          outputs.add(new Object[] { mat.group(1).trim() });
+          throw new Error("Capturing group 1 of " + m_pattern + "did not match in " + m_contents);
         }
-        else
-        {
-          outputs.add(new Object[] { mat.group(1) });
-        }
+      } else {
+        matched = mat.group();
       }
-      else
+      if (m_trim)
       {
-        if (m_trim)
-        {
-          outputs.add(new Object[] { mat.group(0).trim() });
-        }
-        else
-        {
-          outputs.add(new Object[] { mat.group(0) });
-        }
+        matched = matched.trim();
       }
+      outputs.add(new Object[] { matched });
       last_end = mat.end();
     }
     m_contents = m_contents.substring(last_end);


### PR DESCRIPTION
This can happen when there is an optional or an alternation, as when the regex
`(foo)?(bar)`
is matched against the text
`bar`
The user should have written (?:foo)?(bar), but it is better for Beep Beep not to crash in that case.

This pull request also eliminates a bit of code duplication.