### PR TITLE
Eliminate unneeded constructors

### DIFF
--- a/Core/src/ca/uqac/lif/cep/functions/Cumulate.java
+++ b/Core/src/ca/uqac/lif/cep/functions/Cumulate.java
@@ -35,6 +35,12 @@ import ca.uqac.lif.petitpoucet.NodeFunction;
  */
 public class Cumulate extends ApplyFunction
 {
+  // This constructor is used for deserialization.
+  private Cumulate()
+  {
+    super(null);
+  }
+
   public Cumulate(CumulativeFunction<?> f)
   {
     super(f);

--- a/Core/src/ca/uqac/lif/cep/functions/Cumulate.java
+++ b/Core/src/ca/uqac/lif/cep/functions/Cumulate.java
@@ -35,11 +35,6 @@ import ca.uqac.lif.petitpoucet.NodeFunction;
  */
 public class Cumulate extends ApplyFunction
 {
-  private Cumulate()
-  {
-    super(null);
-  }
-  
   public Cumulate(CumulativeFunction<?> f)
   {
     super(f);

--- a/Core/src/ca/uqac/lif/cep/util/Bags.java
+++ b/Core/src/ca/uqac/lif/cep/util/Bags.java
@@ -103,6 +103,12 @@ public class Bags
      */
     protected UnaryFunction<?, Boolean> m_condition;
 
+    // This constructor is used for deserialization.
+    protected FilterElements()
+    {
+      super(Object.class, Object.class);
+    }
+
     /**
      * Gets a new instance of the function
      * 
@@ -111,7 +117,7 @@ public class Bags
      */
     public FilterElements(UnaryFunction<?, Boolean> condition)
     {
-      super(Object.class, Object.class);
+      this();
       m_condition = condition;
     }
 
@@ -449,9 +455,15 @@ public class Bags
      */
     protected Function m_function;
 
-    public ApplyToAll(Function function)
+    // This constructor is used for deserialization.
+    public ApplyToAll()
     {
       super(Object.class, Object.class);
+    }
+
+    public ApplyToAll(Function function)
+    {
+      this();
       m_function = function;
     }
 

--- a/Core/src/ca/uqac/lif/cep/util/Bags.java
+++ b/Core/src/ca/uqac/lif/cep/util/Bags.java
@@ -103,11 +103,6 @@ public class Bags
      */
     protected UnaryFunction<?, Boolean> m_condition;
 
-    protected FilterElements()
-    {
-      super(Object.class, Object.class);
-    }
-
     /**
      * Gets a new instance of the function
      * 
@@ -116,7 +111,7 @@ public class Bags
      */
     public FilterElements(UnaryFunction<?, Boolean> condition)
     {
-      this();
+      super(Object.class, Object.class);
       m_condition = condition;
     }
 
@@ -454,14 +449,9 @@ public class Bags
      */
     protected Function m_function;
 
-    public ApplyToAll()
-    {
-      super(Object.class, Object.class);
-    }
-
     public ApplyToAll(Function function)
     {
-      this();
+      super(Object.class, Object.class);
       m_function = function;
     }
 


### PR DESCRIPTION
The `Cumulate()` constructor private and is never used.
The two in `Bags.java` are not used, and they leave necessary fields unset, so they seem dangerous.