### PR TITLE
Fix Javadoc errors

### DIFF
--- a/Core/src/ca/uqac/lif/cep/Pullable.java
+++ b/Core/src/ca/uqac/lif/cep/Pullable.java
@@ -99,7 +99,7 @@ public interface Pullable extends Iterator<Object>, Iterable<Object>
    * returned otherwise.
    * 
    * @return An event
-   * @throws NoSuchElementException if the iteration has no more elements
+   * @throws java.util.NoSuchElementException if the iteration has no more elements
    */
   public Object pull();
 
@@ -107,7 +107,7 @@ public interface Pullable extends Iterator<Object>, Iterable<Object>
    * Synonym of {@link #pull()}.
    * 
    * @return An event
-   * @throws NoSuchElementException if the iteration has no more elements
+   * @throws java.util.NoSuchElementException if the iteration has no more elements
    */
   @Override
   public Object next();


### PR DESCRIPTION
This pull request eliminates two errors that arise from `ant javadoc`, by using the fully-qualified name for a class that is not imported.