### PR TITLE
Simplify implementation of `Tank.pull`

### DIFF
--- a/Core/src/ca/uqac/lif/cep/tmf/Tank.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Tank.java
@@ -119,11 +119,7 @@ public class Tank extends Processor
     {
       synchronized (m_inputQueues[0])
       {
-        if (m_inputQueues[0].isEmpty())
-        {
-          throw new NoSuchElementException();
-        }
-        return m_inputQueues[0].poll();
+        return m_inputQueues[0].remove();
       }
     }
 


### PR DESCRIPTION
This implementation throws exactly the same `NoSuchElementException`, but I think it's easier to understand.  If you agree, you can merge this; if you disagree, you can close it.