### PR TITLE
Close resources even if method throws an exception

### DIFF
--- a/Core/src/ca/uqac/lif/cep/io/WriteToFile.java
+++ b/Core/src/ca/uqac/lif/cep/io/WriteToFile.java
@@ -71,10 +71,8 @@ public class WriteToFile extends Sink
   {
     String new_filename = createFilename();
     m_outputCount++;
-    try
-    {
-      FileOutputStream fos = new FileOutputStream(new File(new_filename));
-      BufferedOutputStream bos = new BufferedOutputStream(fos);
+    try (FileOutputStream fos = new FileOutputStream(new File(new_filename));
+         BufferedOutputStream bos = new BufferedOutputStream(fos)) {
       if (inputs[0] instanceof byte[])
       {
         bos.write((byte[]) inputs[0]);
@@ -83,7 +81,6 @@ public class WriteToFile extends Sink
       {
         bos.write(inputs[0].toString().getBytes());
       }
-      bos.close();
     }
     catch (FileNotFoundException e)
     {


### PR DESCRIPTION
If `compute()` thrown an exception, then the streams are not closed.
This pull request uses the try-with-resources statement to ensure that the streams are closed even if an exception is thrown.