### PR TITLE
Don't initialize non-null variables to null

### DIFF
--- a/Core/src/ca/uqac/lif/cep/GroupProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/GroupProcessor.java
@@ -43,22 +43,22 @@ public class GroupProcessor extends Processor implements Stateful
   /**
    * The set of processors included in the group
    */
-  private List<Processor> m_processors = null;
+  private List<Processor> m_processors;
 
   /**
    * The set of sources included in the group
    */
-  private HashSet<Source> m_sources = null;
+  private HashSet<Source> m_sources;
 
   /**
    * The {@link Pushable}s associated to each of the processor's input traces
    */
-  private transient List<Pushable> m_inputPushables = null;
+  private transient List<Pushable> m_inputPushables;
 
   /**
    * The {@link Pullable}s associated to each of the processor's output traces
    */
-  private transient List<Pullable> m_outputPullables = null;
+  private transient List<Pullable> m_outputPullables;
 
   /**
    * Whether to notify the QueueSource objects in the group to push an event when

--- a/Core/src/ca/uqac/lif/cep/tmf/AbstractSlice.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/AbstractSlice.java
@@ -70,12 +70,12 @@ public abstract class AbstractSlice extends SynchronousProcessor implements Stat
   /**
    * The slicing function
    */
-  protected Function m_slicingFunction = null;
+  protected Function m_slicingFunction;
 
   /**
    * The internal processor
    */
-  protected Processor m_processor = null;
+  protected Processor m_processor;
 
   /**
    * The cleaning function

--- a/Core/src/ca/uqac/lif/cep/tmf/AbstractWindow.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/AbstractWindow.java
@@ -53,7 +53,7 @@ public abstract class AbstractWindow extends SynchronousProcessor
   /**
    * The internal processor
    */
-  protected Processor m_processor = null;
+  protected Processor m_processor;
 
   /**
    * Creates a new abstract window processor

--- a/Core/src/ca/uqac/lif/cep/tmf/Window.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Window.java
@@ -54,7 +54,7 @@ public class Window extends AbstractWindow implements Stateful
   /**
    * The sink that will receive the events produced by the inner processor
    */
-  protected SinkLast m_sink = null;
+  protected SinkLast m_sink;
 
   /**
    * Creates a new window processor


### PR DESCRIPTION
Ordinarily, it does no harm to initialize a variable to null.
However, such an initialization is misleading if the variable will always be set, and it's doubly misleading if the variable is always set to a non-null value.  I think that is the case for all these changes (that is, the variable is never null).