### PR TITLE
Centralize initialization

### DIFF
--- a/Core/src/ca/uqac/lif/cep/tmf/SinkLast.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/SinkLast.java
@@ -32,12 +32,12 @@ public class SinkLast extends Sink
   /**
    * The last event (or array of events) received
    */
-  protected Object[] m_last;
+  protected Object[] m_last = null;
 
   /**
    * The number of events received so far
    */
-  protected int m_eventCounter;
+  protected int m_eventCounter = 0;
 
   /**
    * Creates a new sink last processor
@@ -45,8 +45,6 @@ public class SinkLast extends Sink
   public SinkLast()
   {
     super();
-    m_last = null;
-    m_eventCounter = 0;
   }
 
   /**
@@ -56,8 +54,6 @@ public class SinkLast extends Sink
   public SinkLast(int in_arity)
   {
     super(in_arity);
-    m_last = null;
-    m_eventCounter = 0;
   }
 
   @Override


### PR DESCRIPTION
This is purely a style improvment.
I think it's clearer to write the initialization once, rather than repeating it in each constructor, forcing the programmer to compare them to verify that they are not different and that no constructor lacks the initialization.