### PR TITLE
Fix null pointer exception

### DIFF
--- a/Core/src/ca/uqac/lif/cep/GroupProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/GroupProcessor.java
@@ -1034,7 +1034,10 @@ public class GroupProcessor extends Processor implements Stateful
   public final Processor setEventTracker(/*@ null @*/ EventTracker tracker)
   {
     super.setEventTracker(tracker);
-    tracker.add(this);
+    if (tracker != null)
+    {
+      tracker.add(this);
+    }
     if (tracker != null && m_innerTracker == null)
     {
       m_innerTracker = tracker.getCopy(false);


### PR DESCRIPTION
The formal parameter `tracker` can be null, but the body of the method unconditionally dereferences it.