### PR TITLE
Use `{@code ...}` instead of `<tt>...</tt>`

### DIFF
--- a/Core/src/ca/uqac/lif/cep/AsynchronousProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/AsynchronousProcessor.java
@@ -263,8 +263,8 @@ public abstract class AsynchronousProcessor extends Processor
    *          this queue for every output front it produces. The size of each
    *          array should be equal to the processor's output arity, although this
    *          is not enforced.
-   * @return <tt>true</tt> if this processor may output other events in the
-   * future, <tt>false</tt> otherwise
+   * @return {@code true} if this processor may output other events in the
+   * future, {@code false} otherwise
    */
   protected abstract boolean compute(Object[] inputs, Queue<Object[]> outputs);
 

--- a/Core/src/ca/uqac/lif/cep/Connector.java
+++ b/Core/src/ca/uqac/lif/cep/Connector.java
@@ -33,8 +33,8 @@ import java.util.Set;
  * QueueSource(2, 1), Connector.connect(new QueueSource(1, 1), new Addition(),
  * 0, 0), 0, 1); ```
  * 
- * In the previous example, the inner call to <code>connect()</code> links
- * output 0 of a <code>QueueSource</code> to input 0 of an `Addition` processor;
+ * In the previous example, the inner call to {@code connect()} links
+ * output 0 of a {@code QueueSource} to input 0 of an `Addition` processor;
  * this partially-connected `Addition` is the return value of this method. It is
  * then used in the outer call, where another `QueueSource` is linked to its
  * input 1. This fully-connected `Addition` is what is put into variable `p`.
@@ -106,8 +106,8 @@ public class Connector
   }
 
   /**
-   * Connects the <i>i</i>-th output of <tt>p1</tt> to the <i>j</i>-th input of
-   * <tt>p2</tt>
+   * Connects the <i>i</i>-th output of {@code p1} to the <i>j</i>-th input of
+   * {@code p2}
    * 
    * @param tracker
    *          An event tracker (optional)
@@ -172,8 +172,8 @@ public class Connector
   }
 
   /**
-   * Connects the <i>i</i>-th output of <tt>p1</tt> to the <i>j</i>-th input of
-   * <tt>p2</tt>
+   * Connects the <i>i</i>-th output of {@code p1} to the <i>j</i>-th input of
+   * {@code p2}
    * 
    * @param p1
    *          The first processor
@@ -238,8 +238,8 @@ public class Connector
   }
 
   /**
-   * Checks if the <i>i</i>-th output of processor <code>p1</code> has a declared
-   * type compatible with the <i>j</i>-th input of processor <code>p2</code>
+   * Checks if the <i>i</i>-th output of processor {@code p1} has a declared
+   * type compatible with the <i>j</i>-th input of processor {@code p2}
    * 
    * @param p1
    *          The first processor
@@ -266,8 +266,8 @@ public class Connector
   }
 
   /**
-   * Checks if the <i>i</i>-th output of processor <code>p1</code> has a declared
-   * type compatible with the <i>j</i>-th input of processor <code>p2</code>, and
+   * Checks if the <i>i</i>-th output of processor {@code p1} has a declared
+   * type compatible with the <i>j</i>-th input of processor {@code p2}, and
    * throws an appropriate exception if not
    * 
    * @param p1

--- a/Core/src/ca/uqac/lif/cep/Duplicable.java
+++ b/Core/src/ca/uqac/lif/cep/Duplicable.java
@@ -33,7 +33,7 @@ public interface Duplicable
 {
   /**
    * Duplicates an object and sets it to its initial state. This should be the
-   * same thing as calling <tt>duplicate(false)</tt>.
+   * same thing as calling {@code duplicate(false)}.
    * 
    * @return Another object
    */
@@ -44,7 +44,7 @@ public interface Duplicable
    * source object.
    * 
    * @param with_state
-   *          Set to <tt>true</tt> to replicate the object's state, <tt>false</tt>
+   *          Set to {@code true} to replicate the object's state, {@code false}
    *          to create a new copy in the initial state.
    * @return Another object
    */

--- a/Core/src/ca/uqac/lif/cep/GroupProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/GroupProcessor.java
@@ -69,14 +69,14 @@ public class GroupProcessor extends Processor implements Stateful
   /**
    * A map between numbers and processor associations. An element (m,(n,p)) of
    * this map means that the <i>m</i>-th input of the group processor is in fact
-   * the <i>n</i>-th input of processor <code>p</code>
+   * the <i>n</i>-th input of processor {@code p}
    */
   private HashMap<Integer, ProcessorAssociation> m_inputPullableAssociations;
 
   /**
    * A map between numbers and processor associations. An element (m,(n,p)) of
    * this map means that the <i>m</i>-th output of the group processor is in fact
-   * the <i>n</i>-th output of processor <code>p</code>
+   * the <i>n</i>-th output of processor {@code p}
    */
   private HashMap<Integer, ProcessorAssociation> m_outputPushableAssociations;
 
@@ -118,7 +118,7 @@ public class GroupProcessor extends Processor implements Stateful
    * event when a call to push is made on the group.
    * 
    * @param b
-   *          Set to <tt>true</tt> to notify the sources
+   *          Set to {@code true} to notify the sources
    * @return This group processor
    */
   public GroupProcessor notifySources(boolean b)
@@ -129,7 +129,7 @@ public class GroupProcessor extends Processor implements Stateful
   
   /**
    * Gets the tracker instance for the processors contained in this group.
-   * @return The tracker instance, or <tt>null</tt> if no inner tracker is set.
+   * @return The tracker instance, or {@code null} if no inner tracker is set.
    * @since 0.11
    */
   /*@ pure null @*/ public EventTracker getInnerTracker()
@@ -225,14 +225,14 @@ public class GroupProcessor extends Processor implements Stateful
 
   /**
    * Declares that the <i>i</i>-th input of the group is linked to the <i>j</i>-th
-   * input of processor <code>p</code>
+   * input of processor {@code p}
    * 
    * @param i
    *          The number of the input of the group
    * @param p
    *          The processor to connect to
    * @param j
-   *          The number of the input of processor <code>p</code>
+   *          The number of the input of processor {@code p}
    * @return A reference to the current group processor
    */
   public synchronized GroupProcessor associateInput(int i, Processor p, int j)
@@ -251,7 +251,7 @@ public class GroupProcessor extends Processor implements Stateful
    * @param p
    *          The processor to connect to
    * @param j
-   *          The number of the output of processor <code>p</code>
+   *          The number of the output of processor {@code p}
    * @return A reference to the current group processor
    */
   public synchronized GroupProcessor associateOutput(int i, Processor p, int j)
@@ -360,7 +360,7 @@ public class GroupProcessor extends Processor implements Stateful
    *          The {@link GroupProcessor} to clone into. When the method is called,
    *          it is expected to be empty.
    * @param with_state
-   *          It set to <tt>true</tt>, each processor in the new group has the same
+   *          It set to {@code true}, each processor in the new group has the same
    *          events in its input/output buffers as in the original. Otherwise,
    *          the queues are empty.
    * @return An association between IDs and the new processors that have been put
@@ -437,7 +437,7 @@ public class GroupProcessor extends Processor implements Stateful
    * @param p
    *          The processor to copy. Nothing is changed on this processor.
    * @param with_state
-   *          If set to <tt>true</tt>, the new copy has the same events in its
+   *          If set to {@code true}, the new copy has the same events in its
    *          input/output buffers as the original. Otherwise, the queues are
    *          empty.
    * @return The new processor
@@ -749,8 +749,8 @@ public class GroupProcessor extends Processor implements Stateful
      * Pushes output event (if any) to the corresponding output {@link Pushable}s.
      *
      * @param temp_queue The queue of object fronts to push
-     * @param outs Set to <tt>true</tt> to enable the output of an event,
-     * <tt>false</tt> otherwise.
+     * @param outs Set to {@code true} to enable the output of an event,
+     * {@code false} otherwise.
      */
     private final void outputEvent(Queue<Object[]> temp_queue, boolean outs)
     {
@@ -813,7 +813,7 @@ public class GroupProcessor extends Processor implements Stateful
    * 
    * @param index
    *          The index
-   * @return The processor, or <tt>null</tt> if no processor is associated to this
+   * @return The processor, or {@code null} if no processor is associated to this
    *         index
    */
   public Processor getAssociatedInput(int index)
@@ -852,7 +852,7 @@ public class GroupProcessor extends Processor implements Stateful
    * 
    * @param index
    *          The index
-   * @return The index, or <tt>-1</tt> if no processor is associated to this
+   * @return The index, or {@code -1} if no processor is associated to this
    *         index
    */
   public int getAssociatedInputIndex(int index)
@@ -869,7 +869,7 @@ public class GroupProcessor extends Processor implements Stateful
    * 
    * @param index
    *          The index
-   * @return The processor, or <tt>null</tt> if no processor is associated to this
+   * @return The processor, or {@code null} if no processor is associated to this
    *         index
    */
   public Processor getAssociatedOutput(int index)
@@ -887,7 +887,7 @@ public class GroupProcessor extends Processor implements Stateful
    * 
    * @param index
    *          The index
-   * @return The index, or <tt>-1</tt> if no processor is associated to this
+   * @return The index, or {@code -1} if no processor is associated to this
    *         index
    */
   public int getAssociatedOutputIndex(int index)

--- a/Core/src/ca/uqac/lif/cep/Processor.java
+++ b/Core/src/ca/uqac/lif/cep/Processor.java
@@ -247,7 +247,7 @@ public abstract class Processor implements DuplicableProcessor,
    * 
    * @param key
    *          The key associated to that object
-   * @return The object, or <code>null</code> if no object exists with such key
+   * @return The object, or {@code null} if no object exists with such key
    */
   public final synchronized /*@ null @*/ Object getContext(/*@ non_null @*/ String key)
   {
@@ -397,7 +397,7 @@ public abstract class Processor implements DuplicableProcessor,
    *          The index. Should be between 0 and the processor's output arity - 1
    *          (since indices start at 0).
    * @return The pullable if the index is within the appropriate range,
-   *         <code>null</code> otherwise.
+   *         {@code null} otherwise.
    */
   public abstract /*@ non_null @*/ Pullable getPullableOutput(int index);
 
@@ -500,8 +500,8 @@ public abstract class Processor implements DuplicableProcessor,
    * 
    * @param v
    *          The array
-   * @return <code>true</code> if all elements in the array are null,
-   *         <code>false</code> otherwise
+   * @return {@code true} if all elements in the array are null,
+   *         {@code false} otherwise
    */
   public static boolean allNull(Object[] v)
   {
@@ -539,12 +539,12 @@ public abstract class Processor implements DuplicableProcessor,
    * Gets the type of events the processor accepts for its <i>i</i>-th input
    * trace. Note that this method returns a <em>set</em>, in the case where the
    * processor accepts various types of objects (for example, a processor
-   * accepting <code>Number</code>s, but also <code>String</code>s it converts
+   * accepting {@code Number}s, but also {@code String}s it converts
    * into numbers internally).
    * 
    * @param index
    *          The index of the input to query
-   * @return A set of classes. If <code>index</code> it less than 0 or greater
+   * @return A set of classes. If {@code index} is less than 0 or greater
    *         than the processor's declared input arity, the set will be empty.
    */
   //@ requires index >= 0
@@ -590,7 +590,7 @@ public abstract class Processor implements DuplicableProcessor,
    * 
    * @param index
    *          The index of the output to query
-   * @return The type of the output. If <code>index</code> it less than 0 or
+   * @return The type of the output. If {@code index} it less than 0 or
    *         greater than the processor's declared output arity, this method
    *         <em>may</em> throw an IndexOutOfBoundsException.
    */
@@ -667,7 +667,7 @@ public abstract class Processor implements DuplicableProcessor,
   /**
    * Gets the instance of event tracker associated to this processor
    * 
-   * @return The event tracker, or <tt>null</tt> of no event tracker is associated
+   * @return The event tracker, or {@code null} of no event tracker is associated
    *         to this processor
    */
   public final /*@ null @*/ EventTracker getEventTracker()
@@ -679,7 +679,7 @@ public abstract class Processor implements DuplicableProcessor,
    * Associates an event tracker to this processor
    * 
    * @param tracker
-   *          The event tracker, or <tt>null</tt> to remove the association to an
+   *          The event tracker, or {@code null} to remove the association to an
    *          existing tracker
    * @return This processor
    */
@@ -819,7 +819,7 @@ public abstract class Processor implements DuplicableProcessor,
    * A concrete processor should override this method to add whatever state
    * information that needs to be preserved in the serialization process.
    * @return Any object representing the processor's state 
-   * (including <tt>null</tt>)
+   * (including {@code null})
    * @since 0.10.2
    */
   protected Object printState()
@@ -972,13 +972,13 @@ public abstract class Processor implements DuplicableProcessor,
    * <p>
    * Java programmers probably won't use this method, but users of the Groovy
    * language can benefit from its operator overloading conventions, which map
-   * the construct <tt>p | q</tt> to <tt>p.or(q)</tt>. This can be used to
+   * the construct {@code p | q} to {@code p.or(q)}. This can be used to
    * easily pipe two processors together:
-   * <pre><code>
+   * <pre>{@code 
    * def p = (some processor)
    * def q = (some other processor)
    * p | q // Connects p to q
-   * </code></pre>
+   * }</pre>
    * @param p The other processor
    * @return The other processor
    * @since 0.10.9
@@ -996,14 +996,14 @@ public abstract class Processor implements DuplicableProcessor,
    * Java programmers probably won't use this method. However, combined with
    * the definition of {@link #getAt(int)}, users of the Groovy language
    * can benefit from its operator overloading conventions, which map
-   * the construct <tt>p | q</tt> to <tt>p.or(q)</tt>. This can be used to
+   * the construct {@code p | q} to {@code p.or(q)}. This can be used to
    * easily pipe two processors together:
-   * <pre><code>
+   * <pre>{@code 
    * def p = (some processor)
    * def q = (some other processor)
    * p | q[1] // Connects p to pipe index 1 of q
-   * </code></pre>
-   * The above example works because <tt>q[1]</tt> returns <tt>q</tt>'s
+   * }</pre>
+   * The above example works because {@code q[1]} returns {@code q}'s
    * input pushable for pipe index 1.
    * @param p The pushable object representing the input of the other processor
    * to which the current output should be connected.
@@ -1024,14 +1024,14 @@ public abstract class Processor implements DuplicableProcessor,
    * <p>
    * Java programmers probably won't use this method, but users of the Groovy
    * language can benefit from its operator overloading conventions, which map
-   * the construct <tt>p[x]</tt> to <tt>p.getAt(x)</tt>. Combined with the
+   * the construct {@code p[x]} to {@code p.getAt(x)}. Combined with the
    * definition of {@link #or(Pushable)}, this can be used to easily pipe two
    * processors together:
-   * <pre><code>
+   * <pre>{@code 
    * def p = (some processor)
    * def q = (some other processor)
    * p | q[1] // Connects p to pipe index 1 of q
-   * </code></pre>
+   * }</pre>
    * @param index The input pipe index
    * @return The pushable object
    * @since 0.10.9

--- a/Core/src/ca/uqac/lif/cep/Pullable.java
+++ b/Core/src/ca/uqac/lif/cep/Pullable.java
@@ -22,11 +22,11 @@ import java.util.Iterator;
 /**
  * Queries events on one of a processor's outputs. For a processor with an
  * output arity <i>n</i>, there exists <i>n</i> distinct pullables, namely one for
- * each output pipe. Every pullable works roughly like a classical <tt>Iterator</tt>:
+ * each output pipe. Every pullable works roughly like a classical {@code Iterator}:
  * it is possible to check whether new output events are available, and get one
  * new output event.
  * <p>
- * However, contrarily to iterators, <tt>Pullable</tt>s have two versions of each
+ * However, contrarily to iterators, {@code Pullable}s have two versions of each
  * method: a <em>soft</em> and a <em>hard</em> version.
  * 
  * <ul>
@@ -35,22 +35,22 @@ import java.util.Iterator;
  * processors are connected in a chain, this generally means pulling events from
  * the input in order to produce the output. However, if pulling the input
  * produces no event, no output event can be produced. In such a case,
- * {@link #hasNextSoft()} will return a special value (<code>MAYBE</code>), and
- * {@link #pullSoft()} will return <code>null</code>. Soft methods can be seen a
+ * {@link #hasNextSoft()} will return a special value ({@code MAYBE}), and
+ * {@link #pullSoft()} will return {@code null}. Soft methods can be seen a
  * doing "one turn of the crank" on the whole chain of processors --whether or
  * not this outputs something.</li>
  * <li><strong>Hard</strong> methods are actually calls to soft
  * methods until an output event is produced: the "crank" is turned as long as
  * necessary to produce something. This means that one call to, e.g.
  * {@link #pull()} may consume more than one event from a processor's input.
- * Therefore, calls to {@link #hasNext()} never return <code>MAYBE</code> (only
- * <code>YES</code> or <code>NO</code>), and {@link #pull()} throws
+ * Therefore, calls to {@link #hasNext()} never return {@code MAYBE} (only
+ * {@code YES} or {@code NO}), and {@link #pull()} throws
  *  {@code NoSuchElementException} only if no event will ever be output in the future (this
  * occurs, for example, when pulling events from a file, and the end of the file
  * has been reached).</li>
  * </ul>
  * <p>
- * The lifecycle of a <tt>Pullable</tt> object is as follows:
+ * The lifecycle of a {@code Pullable} object is as follows:
  * 
  * <ul>
  * <li>One obtains a reference to one of a processor's pullables. This can be done
@@ -63,8 +63,8 @@ import java.util.Iterator;
  * next available output event.</li>
  * </ul>
  * 
- * The Pullable interface extends the <tt>Iterator</tt> and <tt>Iterable</tt>
- * interfaces. This means that an instance of <tt>Pullable</tt> can also be iterated over like this:
+ * The Pullable interface extends the {@code Iterator} and {@code Iterable}
+ * interfaces. This means that an instance of {@code Pullable} can also be iterated over like this:
  * <pre>
  * Pullable p = ...; 
  * for (Object o : p) {
@@ -72,11 +72,11 @@ import java.util.Iterator;
  * }
  * </pre>
  * <p>
- * Note however that if <code>p</code> refers to a processor producing an
+ * Note however that if {@code p} refers to a processor producing an
  * infinite number of events, this loop will never terminate by itself.
  * <p>
  * For the same processor, mixing calls to soft and hard methods is discouraged.
- * As a matter of fact, the <tt>Pullable</tt>'s behaviour in such a situation is left
+ * As a matter of fact, the {@code Pullable}'s behaviour in such a situation is left
  * undefined.
  * 
  * @author Sylvain Hallé
@@ -86,17 +86,17 @@ public interface Pullable extends Iterator<Object>, Iterable<Object>
 {
   /**
    * Attempts to pull an event from the source. An event is returned if
-   * {@link #hasNextSoft()} returns <code>YES</code>, and <code>null</code> is
+   * {@link #hasNextSoft()} returns {@code YES}, and {@code null} is
    * returned otherwise.
    * 
-   * @return An event, or <code>null</code> if none could be retrieved
+   * @return An event, or {@code null} if none could be retrieved
    */
   public Object pullSoft();
 
   /**
    * Attempts to pull an event from the source. An event is returned if
-   * {@link #hasNext()} returns <code>YES</code>, and
-   * <code>java.util.NoSuchElementException</code> is thrown otherwise.
+   * {@link #hasNext()} returns {@code YES}, and
+   * {@code java.util.NoSuchElementException} is thrown otherwise.
    * 
    * @return An event
    * @throws java.util.NoSuchElementException if the iteration has no more elements
@@ -105,8 +105,8 @@ public interface Pullable extends Iterator<Object>, Iterable<Object>
 
   /**
    * Attempts to obtain an event from the source. An event is returned if
-   * {@link #hasNext()} returns <code>YES</code>, and
-   * <code>java.util.NoSuchElementException</code> is thrown otherwise.
+   * {@link #hasNext()} returns {@code YES}, and
+   * {@code java.util.NoSuchElementException} is thrown otherwise.
    * 
    * @return An event
    * @throws java.util.NoSuchElementException if the iteration has no more elements
@@ -185,7 +185,7 @@ public interface Pullable extends Iterator<Object>, Iterable<Object>
    * {@link #hasNext()} and {@link #hasNextSoft()} will not be called anymore. For
    * some types of pullables, this can be used as a cue to free some resources
    * (such as threads). The behaviour of these four methods after
-   * <code>dispose()</code> has been called is undefined. In future versions, it
+   * {@code dispose()} has been called is undefined. In future versions, it
    * is possible that an exception will be thrown in such a case.
    */
   public void dispose();
@@ -194,7 +194,7 @@ public interface Pullable extends Iterator<Object>, Iterable<Object>
    * A runtime exception indicating that something went wrong when attempting to
    * check if a next event exists. This happens, for example, if one of a
    * processor's inputs it not connected to anything. Rather than throwing a
-   * <tt>NullPointerException</tt>, the issue will be wrapped within a
+   * {@code NullPointerException}, the issue will be wrapped within a
    * PullableException with a better error message.
    */
   public static class PullableException extends RuntimeException
@@ -334,12 +334,12 @@ public interface Pullable extends Iterator<Object>, Iterable<Object>
    * The "next" status of a {@link Pullable} object. Indicates whether a new
    * output event is available (i.e. can be "pulled").
    * <ul>
-   * <li><code>YES</code> indicates that a new event can be pulled right now,
+   * <li>{@code YES} indicates that a new event can be pulled right now,
    * using either {@link #pullSoft()} or {@link #pull()}</li>
-   * <li><code>NO</code> indicates that no event is available, and will ever be.
-   * Receiving <code>NO</code> generally indicates that the end of the (output)
+   * <li>{@code NO} indicates that no event is available, and will ever be.
+   * Receiving {@code NO} generally indicates that the end of the (output)
    * trace has been reached</li>
-   * <li><code>MAYBE</code> indicates that no event is available, but that keeping
+   * <li>{@code MAYBE} indicates that no event is available, but that keeping
    * on pulling <em>may </em>produce an event in the future. This value is only
    * returned by {@link #hasNextSoft()}.</li>
    * </ul>

--- a/Core/src/ca/uqac/lif/cep/Pushable.java
+++ b/Core/src/ca/uqac/lif/cep/Pushable.java
@@ -40,27 +40,27 @@ public interface Pushable
    * push operation is completely done.
    * 
    * @param o
-   *          The event. Although you can technically push <code>null</code>, the
-   *          behaviour in this case is undefined. It <code>may</code> be
+   *          The event. Although you can technically push {@code null}, the
+   *          behaviour in this case is undefined. It <em>may</em> be
    *          interpreted as if you are passing no event.
    * @return The same instance of pushable. This is done to allow chain calls to
-   *         {@link Pushable} objects, e.g. <code>p.push(o1).push(o2)</code>.
+   *         {@link Pushable} objects, e.g. {@code p.push(o1).push(o2)}.
    */
   public Pushable push(Object o);
 
   /**
    * Pushes an event into one of the processor's input trace, but does not wait
    * for the push operation to terminate. In other words, this is a non-blocking
-   * call to <code>push()</code> that returns control to the caller immediately.
+   * call to {@code push()} that returns control to the caller immediately.
    * In order to resynchronize the caller with the result of the push operation,
-   * one must use the <tt>Future</tt> object that the method returns.
+   * one must use the {@code Future} object that the method returns.
    * 
    * @param o
-   *          The event. Although you can technically push <code>null</code>, the
-   *          behaviour in this case is undefined. It <code>may</code> be
+   *          The event. Although you can technically push {@code null}, the
+   *          behaviour in this case is undefined. It <em>may</em> be
    *          interpreted as if you are passing no event.
    * @return A {@link Future} object that can be used to wait until the call to
-   *         <tt>pushFast</tt> is finished.
+   *         {@code pushFast} is finished.
    */
   public Future<Pushable> pushFast(Object o);
 
@@ -92,7 +92,7 @@ public interface Pushable
    * A runtime exception indicating that something went wrong when attempting to
    * check if a next event exists. This happens, for example, if one of a
    * processor's inputs it not connected to anything. Rather than throwing a
-   * <tt>NullPointerException</tt>, the issue will be wrapped within a
+   * {@code NullPointerException}, the issue will be wrapped within a
    * PullableException with a better error message.
    */
   public static class PushableException extends RuntimeException

--- a/Core/src/ca/uqac/lif/cep/Stateful.java
+++ b/Core/src/ca/uqac/lif/cep/Stateful.java
@@ -20,12 +20,12 @@ package ca.uqac.lif.cep;
 /**
  * Interface implemented by processors that can publicly expose a token
  * equivalent to their internal state. This token can be an arbitrary
- * object, including <tt>null</tt>. However, it must follow this condition:
+ * object, including {@code null}. However, it must follow this condition:
  * if two processor instances &pi;<sub>1</sub> and &pi;<sub>2</sub> (of
  * the same class) respectively return two state tokens <i>s</i><sub>1</sub>
  * and <i>s</i><sub>2</sub> such that 
- * <i>s</i><sub>1</sub><tt>.equals(</tt><i>s</i><sub>2</sub><tt>) ==
- * true</tt>, then for any sequence of inputs, &pi;<sub>1</sub>
+ * <i>s</i><sub>1</sub>{@code .equals(}<i>s</i><sub>2</sub>{@code ) ==
+ * true}, then for any sequence of inputs, &pi;<sub>1</sub>
  * and &pi;<sub>2</sub> must generate the same output.
  * 
  * @author Sylvain Hallé

--- a/Core/src/ca/uqac/lif/cep/SynchronousProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/SynchronousProcessor.java
@@ -41,7 +41,7 @@ import java.util.concurrent.Future;
  * implement.
  * <p>
  * In early versions of the library, this class was called
- * <tt>SingleProcessor</tt>.
+ * {@code SingleProcessor}.
  * 
  * @author Sylvain Hallé
  * @since 0.1
@@ -113,8 +113,8 @@ public abstract class SynchronousProcessor extends Processor
    *          this queue for every output front it produces. The size of each
    *          array should be equal to the processor's output arity, although this
    *          is not enforced.
-   * @return <tt>true</tt> if this processor may output other events in the
-   * future, <tt>false</tt> otherwise
+   * @return {@code true} if this processor may output other events in the
+   * future, {@code false} otherwise
    */
   protected abstract boolean compute(Object[] inputs, Queue<Object[]> outputs);
 
@@ -238,8 +238,8 @@ public abstract class SynchronousProcessor extends Processor
     /**
      * Pushes output event (if any) to the corresponding output {@link Pushable}s.
      *
-     * @param outs Set to <tt>true</tt> to enable the output of an event,
-     * <tt>false</tt> otherwise.
+     * @param outs Set to {@code true} to enable the output of an event,
+     * {@code false} otherwise.
      */
     private final void outputEvent(boolean outs)
     {

--- a/Core/src/ca/uqac/lif/cep/TypedPullable.java
+++ b/Core/src/ca/uqac/lif/cep/TypedPullable.java
@@ -32,7 +32,7 @@ import java.util.Iterator;
  * <strong>Caveat emptor:</strong> This pullable simply <em>casts</em> what it
  * receives from its underlying pullable to the type it was created with. It is
  * up to the user to make sure that this cast makes sense; otherwise, a
- * <tt>ClassCastException</tt> will be thrown at runtime.
+ * {@code ClassCastException} will be thrown at runtime.
  * 
  * @author Sylvain Hallé
  * @since 0.2.1

--- a/Core/src/ca/uqac/lif/cep/functions/ApplyFunction.java
+++ b/Core/src/ca/uqac/lif/cep/functions/ApplyFunction.java
@@ -34,7 +34,7 @@ import java.util.Set;
  * to produce the outputs.
  * <p>
  * In earlier versions of the library, this class was called
- * <tt>FunctionProcessor</tt>.
+ * {@code FunctionProcessor}.
  * 
  * @author Sylvain Hallé
  * @since 0.2.1

--- a/Core/src/ca/uqac/lif/cep/functions/ContextVariable.java
+++ b/Core/src/ca/uqac/lif/cep/functions/ContextVariable.java
@@ -21,7 +21,7 @@ import ca.uqac.lif.cep.Context;
 import ca.uqac.lif.cep.EventTracker;
 
 /**
- * Placeholder for the value of a context element. A <tt>ContextVariable</tt>
+ * Placeholder for the value of a context element. A {@code ContextVariable}
  * can be given as an argument to a {@link FunctionTree}.
  * 
  * @author Sylvain Hallé

--- a/Core/src/ca/uqac/lif/cep/functions/Cumulate.java
+++ b/Core/src/ca/uqac/lif/cep/functions/Cumulate.java
@@ -30,7 +30,7 @@ import ca.uqac.lif.petitpoucet.NodeFunction;
  * <img src="{@docRoot}/doc-files/functions/Cumulate.png" alt="Cumulate">
  * <p>
  * In earlier versions of the library, this class was called
- * <tt>CumulativeProcessor</tt>.
+ * {@code CumulativeProcessor}.
  * @author Sylvain Hallé
  * @since 0.1
  */

--- a/Core/src/ca/uqac/lif/cep/functions/Function.java
+++ b/Core/src/ca/uqac/lif/cep/functions/Function.java
@@ -119,8 +119,8 @@ public abstract class Function implements DuplicableFunction, Printable, Readabl
    *          arguments contains placeholders, they will be replaced by the
    *          corresponding object fetched from this map before evaluating the
    *          function
-   * @return <tt>true</tt> if the function succeeded in producing an output
-   *          value, <tt>false</tt> otherwise
+   * @return {@code true} if the function succeeded in producing an output
+   *          value, {@code false} otherwise
    */
   /*@ pure @*/ public boolean evaluatePartial(/*@ non_null @*/ Object[] inputs, 
       /*@ non_null @*/ Object[] outputs, /*@ null @*/ Context context)
@@ -147,8 +147,8 @@ public abstract class Function implements DuplicableFunction, Printable, Readabl
    *          The outputs of the function. The size of the array should
    *          be equal to the function's declared output arity. @ Any exception
    *          that may occur during the evaluation of a function
-   * @return <tt>true</tt> if the function succeeded in producing an output
-   *          value, <tt>false</tt> otherwise 
+   * @return {@code true} if the function succeeded in producing an output
+   *          value, {@code false} otherwise 
    */
   /*@ pure @*/ public boolean evaluateLazy(/*@ non_null @*/ Object[] inputs, 
       /*@ non_null @*/ Object[] outputs)
@@ -255,7 +255,7 @@ public abstract class Function implements DuplicableFunction, Printable, Readabl
    * A concrete function should override this method to add whatever state
    * information that needs to be preserved in the serialization process.
    * @return Any object representing the function's state 
-   * (including <tt>null</tt>)
+   * (including {@code null})
    * @since 0.10.2
    */
   protected Object printState()

--- a/Core/src/ca/uqac/lif/cep/functions/PassthroughFunction.java
+++ b/Core/src/ca/uqac/lif/cep/functions/PassthroughFunction.java
@@ -27,8 +27,8 @@ import java.util.Set;
  * <p>
  * The main purpose of this class is to allow one to create a class out of a
  * {@link FunctionTree} instance created programmatically. The code creating the
- * <code>FunctionTree</code> is written in the {@link #getFunction()} method
- * (which, as a matter of fact, can return any other <code>Function</code>
+ * {@code FunctionTree} is written in the {@link #getFunction()} method
+ * (which, as a matter of fact, can return any other {@code Function}
  * object).
  * 
  * @author Sylvain Hallé

--- a/Core/src/ca/uqac/lif/cep/functions/RaiseArity.java
+++ b/Core/src/ca/uqac/lif/cep/functions/RaiseArity.java
@@ -27,7 +27,7 @@ import java.util.Set;
 /**
  * A {@link Function} that raises the arity of another function.
  * Given an <i>m</i>:<i>n</i> function <i>f</i>, an instance of
- * <tt>RaiseArity</tt> <i>r</i> makes <i>f</i> behave like an
+ * {@code RaiseArity} <i>r</i> makes <i>f</i> behave like an
  * <i>m</i>':<i>n</i> function, with <i>m</i>' &gt; <i>m</i>.
  * The extra arguments given to <i>r</i> are simply ignored.
  *  

--- a/Core/src/ca/uqac/lif/cep/io/Print.java
+++ b/Core/src/ca/uqac/lif/cep/io/Print.java
@@ -23,7 +23,7 @@ import java.util.Queue;
 
 /**
  * Sends its input to a PrintStream (such as the standard output). This
- * processor takes whatever event it receives (i.e. any Java <tt>Object</tt>),
+ * processor takes whatever event it receives (i.e. any Java {@code Object}),
  * calls its {@link Object#toString() toString()} method, and pushes the
  * resulting output to a print stream. Graphically, it is represented as:
  * <p>

--- a/Core/src/ca/uqac/lif/cep/io/ReadInputStream.java
+++ b/Core/src/ca/uqac/lif/cep/io/ReadInputStream.java
@@ -98,8 +98,8 @@ public abstract class ReadInputStream extends Source
    * source.
    * 
    * @param b
-   *          Set to <tt>true</tt> to tell the reader it is reading a file,
-   *          <tt>false</tt> otherwise
+   *          Set to {@code true} to tell the reader it is reading a file,
+   *          {@code false} otherwise
    * @return This stream reader
    */
   public ReadInputStream setIsFile(boolean b)

--- a/Core/src/ca/uqac/lif/cep/tmf/AbstractSlice.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/AbstractSlice.java
@@ -57,7 +57,7 @@ import java.util.concurrent.Future;
  * immediately
  * </ul>
  * <p>
- * The function <i>f</i> may return <code>null</code>, or the special object
+ * The function <i>f</i> may return {@code null}, or the special object
  * {@link ToAllSlices}. This indicates that no new slice must be created, but
  * that the incoming event must be dispatched to <em>all</em> slices one by one.
  * 
@@ -300,8 +300,8 @@ public abstract class AbstractSlice extends SynchronousProcessor implements Stat
    * handled as individual slice IDs.
    * 
    * @param b
-   *          Set to <tt>true</tt> to handle collections as multiple IDs. The
-   *          default is <tt>false</tt>
+   *          Set to {@code true} to handle collections as multiple IDs. The
+   *          default is {@code false}
    * @return This slicer
    */
   public AbstractSlice explodeCollections(boolean b)
@@ -396,8 +396,8 @@ public abstract class AbstractSlice extends SynchronousProcessor implements Stat
    * and {@link #handleNewSliceValue(Object, Object, Queue)} has been called
    * for all slices that produced an output event. 
    * @param outputs The processor's output queue
-   * @return <tt>true</tt> if the processor is expected to output new events
-   * in the future, <tt>false</tt> otherwise.
+   * @return {@code true} if the processor is expected to output new events
+   * in the future, {@code false} otherwise.
    */
   protected abstract boolean produceReturn(Queue<Object[]> outputs);
   

--- a/Core/src/ca/uqac/lif/cep/tmf/Freeze.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Freeze.java
@@ -25,10 +25,10 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Repeatedly outputs the first event it has received. <code>Freeze</code> works
+ * Repeatedly outputs the first event it has received. {@code Freeze} works
  * a bit like {@link ca.uqac.lif.cep.functions.Constant Constant}; however, while
- * <code>Constant</code> is
- * given the event to output, <code>Freeze</code> waits for a first event,
+ * {@code Constant} is
+ * given the event to output, {@code Freeze} waits for a first event,
  * outputs it, and then outputs that event whenever some new input comes in.
  * 
  * @author Sylvain Hallé

--- a/Core/src/ca/uqac/lif/cep/tmf/Pad.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Pad.java
@@ -47,7 +47,7 @@ public class Pad extends SynchronousProcessor
    * Creates a Pad processor
    * @param p The processor whose output is to be padded
    * @param times The number of times to pad
-   * @param front The event front to pad before the output of <tt>p</tt>
+   * @param front The event front to pad before the output of {@code p}
    */
   public Pad(Processor p, int times, Object ... front)
   {

--- a/Core/src/ca/uqac/lif/cep/tmf/Passthrough.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Passthrough.java
@@ -22,7 +22,7 @@ import ca.uqac.lif.cep.UniformProcessor;
 
 /**
  * Returns its input as its output. Although it seems useless,
- * <tt>Passthrough</tt> is used internally by interpreters as a
+ * {@code Passthrough} is used internally by interpreters as a
  * placeholder when building processor chains from an expression.
  * <p>
  * Graphically, this processor is represented as:

--- a/Core/src/ca/uqac/lif/cep/tmf/Pump.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Pump.java
@@ -34,8 +34,8 @@ import ca.uqac.lif.cep.Pushable;
  * <p>
  * The repeated pulling of events from its input is started by calling this
  * processor's {@link #start()} method. In the background, this will instantiate
- * a new thread, which will endlessly call <tt>pull()</tt> on whatever input is
- * connected to the pump, and then call <tt>push()</tt> on whatever input is
+ * a new thread, which will endlessly call {@code pull()} on whatever input is
+ * connected to the pump, and then call {@code push()} on whatever input is
  * connected to it.
  * <p>
  * The opposite of the Pump is the {@link ca.uqac.lif.cep.tmf.Tank Tank}.

--- a/Core/src/ca/uqac/lif/cep/tmf/QueueSource.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/QueueSource.java
@@ -30,7 +30,7 @@ import java.util.Queue;
 
 /**
  * Source whose input is a queue of objects. One gives the
- * <code>QueueSource</code> a list of events, and that source sends these events
+ * {@code QueueSource} a list of events, and that source sends these events
  * as its input one by one. When reaching the end of the list, the source
  * returns to the beginning and keeps feeding events from the list endlessly.
  * This behaviour can be changed with {@link #loop(boolean)}.
@@ -147,8 +147,8 @@ public class QueueSource extends Source implements Stateful
    * Sets whether to loop over the events endlessly
    * 
    * @param b
-   *          Set to <code>true</code> to loop over the events endlessly
-   *          (default), or <code>false</code> to play them only once.
+   *          Set to {@code true} to loop over the events endlessly
+   *          (default), or {@code false} to play them only once.
    * @return This queue source
    */
   public QueueSource loop(boolean b)

--- a/Core/src/ca/uqac/lif/cep/tmf/ResetLast.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/ResetLast.java
@@ -26,7 +26,7 @@ import java.util.Queue;
 /**
  * Processor that receives two input streams; it pushes the events of a first
  * stream into a processor, and resets this processor whenever the event on the
- * second input stream is <tt>true</tt>.
+ * second input stream is {@code true}.
  * @author Sylvain Hallé
  * 
  * @since 0.10

--- a/Core/src/ca/uqac/lif/cep/tmf/Sink.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Sink.java
@@ -24,7 +24,7 @@ import ca.uqac.lif.cep.SynchronousProcessor;
 
 /**
  * Receives input events and stores them. As its name implies, the
- * <code>Sink</code> is just that: the end of a pipe of processors where events
+ * {@code Sink} is just that: the end of a pipe of processors where events
  * are input, but which has no output. In other words, a sink is a processor
  * with an output arity of 0.
  * <p>

--- a/Core/src/ca/uqac/lif/cep/tmf/TimeDecimate.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/TimeDecimate.java
@@ -21,7 +21,7 @@ package ca.uqac.lif.cep.tmf;
  * After returning an input event, discards all others for the next *n* seconds.
  * This processor therefore acts as a rate limiter.
  * 
- * Note that this processor uses <code>System.currentTimeMillis()</code> as its
+ * Note that this processor uses {@code System.currentTimeMillis()} as its
  * clock. Moreover, a mode can be specified in order to output the last input
  * event of the trace if it has not been output already.
  *

--- a/Core/src/ca/uqac/lif/cep/tmf/Window.java
+++ b/Core/src/ca/uqac/lif/cep/tmf/Window.java
@@ -168,7 +168,7 @@ public class Window extends AbstractWindow implements Stateful
   }
 
   /**
-   * Trims <i>n</i> events from the beginning of <tt>q</tt>
+   * Trims <i>n</i> events from the beginning of {@code q}
    * 
    * @param n
    *          The number of events to trim. If <i>n</i>&nbsp;&lt;1, trims nothing.

--- a/Core/src/ca/uqac/lif/cep/util/Bags.java
+++ b/Core/src/ca/uqac/lif/cep/util/Bags.java
@@ -88,7 +88,7 @@ public class Bags
   /**
    * Gets all the elements of the collection that satisfy some condition. This
    * condition is specified as an unary function that is successively applied to
-   * each element of the collection; if the function returns <tt>true</tt>, the
+   * each element of the collection; if the function returns {@code true}, the
    * element is added to the output result, otherwise it is discarded.
    * <p>
    * This function preserves the type of the input. That is, if the input is a
@@ -559,7 +559,7 @@ public class Bags
 
   /**
    * Returns any element of a collection. If the collection is empty, returns
-   * <tt>null</tt>.
+   * {@code null}.
    */
   @SuppressWarnings("rawtypes")
   public static class AnyElement extends UnaryFunction<Collection, Object>
@@ -583,10 +583,10 @@ public class Bags
   }
 
   /**
-   * A 1:<i>m</i> function provided by the <tt>Bags</tt> utility class. 
+   * A 1:<i>m</i> function provided by the {@code Bags} utility class. 
    * Given a collection of size *m*, it returns as its <i>m</i> outputs 
    * the elements of the collection. It can be seen as the oppsite of 
-   * <tt>ToArray</tt>, <tt>ToList</tt> and <tt>ToSet</tt>.
+   * {@code ToArray}, {@code ToList} and {@code ToSet}.
    * The ordering of the arguments is 
    * ensured when the input collection is itself ordered. 
    */
@@ -650,7 +650,7 @@ public class Bags
    * 
    * @param o
    *          The object
-   * @return An array, or <tt>null</tt> if the object could not be converted into
+   * @return An array, or {@code null} if the object could not be converted into
    *         an array.
    */
   public static Object[] toObjectArray(Object o)

--- a/Core/src/ca/uqac/lif/cep/util/Equals.java
+++ b/Core/src/ca/uqac/lif/cep/util/Equals.java
@@ -69,7 +69,7 @@ public class Equals extends BinaryFunction<Object, Object, Boolean>
    * </ul>
    * @param x The first object
    * @param y The second object
-   * @return <tt>true</tt> if they are equal, <tt>false</tt> otherwise
+   * @return {@code true} if they are equal, {@code false} otherwise
    */
   public static boolean isEqualTo(Object x, Object y)
   {

--- a/Core/src/ca/uqac/lif/cep/util/FindPattern.java
+++ b/Core/src/ca/uqac/lif/cep/util/FindPattern.java
@@ -82,10 +82,10 @@ public class FindPattern extends SynchronousProcessor
   }
 
   /**
-   * Sets whether to apply <tt>trim()</tt> to each output event
+   * Sets whether to apply {@code trim()} to each output event
    * 
    * @param b
-   *          Set to <tt>true</tt> to trim (default), <tt>false</tt> otherwise
+   *          Set to {@code true} to trim (default), {@code false} otherwise
    * @return This scanner
    */
   public FindPattern trim(boolean b)

--- a/Core/src/ca/uqac/lif/cep/util/Lists.java
+++ b/Core/src/ca/uqac/lif/cep/util/Lists.java
@@ -195,7 +195,7 @@ public class Lists
   /**
    * Accumulates events from a first input pipe, and sends them in a burst into a
    * list based on the Boolean value received on its second input pipe. A value of
-   * <tt>true</tt> triggers the output of a list, while a value of <tt>false</tt>
+   * {@code true} triggers the output of a list, while a value of {@code false}
    * accumulates the event into the existing list.
    * <p>
    * This processor is represented graphically as follows:
@@ -328,8 +328,8 @@ public class Lists
     }
 
     /**
-     * Timer that pushes the contents of <code>m_packedEvents</code> every
-     * <code>m_outputInterval</code> milliseconds.
+     * Timer that pushes the contents of {@code m_packedEvents} every
+     * {@code m_outputInterval} milliseconds.
      */
     protected class Timer implements Runnable
     {

--- a/Core/src/ca/uqac/lif/cep/util/Maps.java
+++ b/Core/src/ca/uqac/lif/cep/util/Maps.java
@@ -253,7 +253,7 @@ public class Maps
     protected Function m_function;
 
     /**
-     * Creates a new <tt>ApplyAll</tt> function
+     * Creates a new {@code ApplyAll} function
      * @param f The function to apply to all the values. Must be
      * a 1:1 function.
      */

--- a/Core/src/ca/uqac/lif/cep/util/Size.java
+++ b/Core/src/ca/uqac/lif/cep/util/Size.java
@@ -27,7 +27,7 @@ import java.util.Map;
  * <li>For a string, the length</li>
  * <li>For a number, the integer value</li>
  * <li>For a collection, a map or an array, the cardinality</li>
- * <li>For anything else (including <tt>null</tt>), 0</li>
+ * <li>For anything else (including {@code null}), 0</li>
  * </ul>
  * 
  * @author Sylvain Hallé

--- a/Core/src/ca/uqac/lif/cep/util/Strings.java
+++ b/Core/src/ca/uqac/lif/cep/util/Strings.java
@@ -239,10 +239,10 @@ public class Strings
     }
 
     /**
-     * Sets whether to apply <tt>trim()</tt> to each substring
+     * Sets whether to apply {@code trim()} to each substring
      * 
      * @param b
-     *          Set to <tt>true</tt> to trim, <tt>false</tt> otherwise
+     *          Set to {@code true} to trim, {@code false} otherwise
      * @return This function
      */
     public SplitString trim(boolean b)

--- a/CoreTest/src/ca/uqac/lif/cep/GroupTest.java
+++ b/CoreTest/src/ca/uqac/lif/cep/GroupTest.java
@@ -257,7 +257,7 @@ public class GroupTest
 	/**
 	 * Try to clone a group processor that is already connected
 	 * to something else. The goal of this test is only to check
-	 * that the call to <code>duplicate()</code> does not throw an exception.
+	 * that the call to {@code duplicate()} does not throw an exception.
 	 * @
 	 */
 	@Test

--- a/CoreTest/src/ca/uqac/lif/cep/tmf/SliceTest.java
+++ b/CoreTest/src/ca/uqac/lif/cep/tmf/SliceTest.java
@@ -359,8 +359,8 @@ public class SliceTest
 	/**
 	 * Slicing function designed specifically for testing the behaviour
 	 * of the slice processors. Given an integer <i>x</i>, it returns
-	 * {@link ToAllSlices} if <i>x</i> is equal to 2, <tt>null</tt> if <i>x</i>
-	 * is equal to 1, and <tt>true</tt> or <tt>false</tt> for the remaining
+	 * {@link ToAllSlices} if <i>x</i> is equal to 2, {@code null} if <i>x</i>
+	 * is equal to 1, and {@code true} or {@code false} for the remaining
 	 * numbers, depending on whether they are even or odd.  
 	 */
 	public static class EvenAll extends UnaryFunction<Number,Object>

--- a/CoreTest/src/ca/uqac/lif/cep/util/UtilTest.java
+++ b/CoreTest/src/ca/uqac/lif/cep/util/UtilTest.java
@@ -48,7 +48,7 @@ import ca.uqac.lif.cep.util.Bags.ToList;
 import ca.uqac.lif.cep.util.Bags.ToSet;
 
 /**
- * Unit tests for functions and processors of the <tt>util</tt> package.
+ * Unit tests for functions and processors of the {@code util} package.
  */
 public class UtilTest 
 {


### PR DESCRIPTION
The former is better style, and Javadoc for Java 17 issues warnings about the latter.

A spot-check indicates that the formatting in the generated `.html` files remains the same.