### PR TITLE
Throw error rather than returning null

### DIFF
--- a/Core/src/ca/uqac/lif/cep/GroupProcessor.java
+++ b/Core/src/ca/uqac/lif/cep/GroupProcessor.java
@@ -335,9 +335,9 @@ public class GroupProcessor extends Processor implements Stateful
   public final synchronized Pushable getPushableOutput(int index)
   {
     ProcessorAssociation a = m_outputPushableAssociations.get(index);
-    if (a == null)
-    {
-    	return null;
+    if (a == null) {
+      throw new IndexOutOfBoundsException(
+          String.format("setPullableInput(%s): %s", index, m_inputPullableAssociations.keySet()));
     }
     return a.m_processor.getPushableOutput(a.m_ioNumber);
   }
@@ -346,9 +346,9 @@ public class GroupProcessor extends Processor implements Stateful
   public final synchronized Pullable getPullableInput(int index)
   {
     ProcessorAssociation a = m_inputPullableAssociations.get(index);
-    if (a == null)
-    {
-    	return null;
+    if (a == null) {
+      throw new IndexOutOfBoundsException(
+          String.format("setPullableInput(%s): %s", index, m_inputPullableAssociations.keySet()));
     }
     return a.m_processor.getPullableInput(a.m_ioNumber);
   }

--- a/Core/src/ca/uqac/lif/cep/functions/ApplyFunctionLambda.java
+++ b/Core/src/ca/uqac/lif/cep/functions/ApplyFunctionLambda.java
@@ -101,7 +101,7 @@ public class ApplyFunctionLambda extends UniformProcessor
       {
         return new Object[] {m_binary.evaluate(inputs[0], inputs[1])};
       }
-      return null;
+      throw new Error("not unary or binary");
     }
   }
 }

--- a/Core/src/ca/uqac/lif/cep/functions/BinaryFunction.java
+++ b/Core/src/ca/uqac/lif/cep/functions/BinaryFunction.java
@@ -132,7 +132,7 @@ public abstract class BinaryFunction<T, V, U> extends Function
    */
   public U getStartValue()
   {
-    return null;
+    throw new Error("getStartValue was not overridden for a cumulative function");
   }
 
   @Override


### PR DESCRIPTION
These are cases where the method's contract seems to indicate that the return value should be non-null, but the method returns null in exceptional circumstances.  I changed those behaviors to throwing an error.

I'm not sure whether this is correct, however; should the contract of (some of) these methods be that they are allowed to return null?