### PR TITLE
Adding a way to indicate a start value from constructor for CumulateFunction

### DIFF
--- a/Core/src/ca/uqac/lif/cep/functions/CumulativeFunction.java
+++ b/Core/src/ca/uqac/lif/cep/functions/CumulativeFunction.java
@@ -22,7 +22,7 @@ import java.util.List;
 
 /**
  * A function with memory.
- * 
+ *
  * @author Sylvain Hallé
  * @since 0.1
  */
@@ -32,6 +32,12 @@ public class CumulativeFunction<T> extends UnaryFunction<T, T>
    * The last value returned by the function
    */
   private T m_lastValue;
+
+  /**
+   * The start value of the function
+   */
+
+  private T m_startValue;
 
   /**
    * The stateless binary function to apply on each call
@@ -44,9 +50,19 @@ public class CumulativeFunction<T> extends UnaryFunction<T, T>
    */
   public CumulativeFunction(BinaryFunction<T, T, T> function)
   {
+    this(function, function.getStartValue());
+  }
+
+  /**
+   * Instantiates a new cumulative function with a start value
+   * @param function the function to cumulate
+   * @param startValue the start value of the function
+   */
+  public CumulativeFunction(BinaryFunction<T, T, T> function, T startValue) {
     super(function.getInputTypeLeft(), function.getOutputType());
     m_function = function;
-    m_lastValue = m_function.getStartValue();
+    m_startValue = startValue;
+    m_lastValue = startValue;
   }
 
   @Override
@@ -67,7 +83,7 @@ public class CumulativeFunction<T> extends UnaryFunction<T, T>
   @Override
   public void reset()
   {
-    m_lastValue = m_function.getStartValue();
+    m_lastValue = this.m_startValue;
   }
 
   @Override
@@ -80,7 +96,7 @@ public class CumulativeFunction<T> extends UnaryFunction<T, T>
     }
     return cf;
   }
-  
+
   /**
    * @since 0.10.2
    */
@@ -92,7 +108,7 @@ public class CumulativeFunction<T> extends UnaryFunction<T, T>
     list.add(m_lastValue);
     return list;
   }
-  
+
   /**
    * @since 0.10.2
    */
@@ -105,14 +121,14 @@ public class CumulativeFunction<T> extends UnaryFunction<T, T>
     cf.m_lastValue = (T) list.get(1);
     return cf;
   }
-  
+
   /**
    * @since 0.11
    * @return The last value
    */
   /*@ pure @*/ public T getLastValue()
   {
-  	return m_lastValue;
+    return m_lastValue;
   }
 
 }

--- a/Core/src/ca/uqac/lif/cep/functions/CumulativeFunction.java
+++ b/Core/src/ca/uqac/lif/cep/functions/CumulativeFunction.java
@@ -26,109 +26,104 @@ import java.util.List;
  * @author Sylvain Hallé
  * @since 0.1
  */
-public class CumulativeFunction<T> extends UnaryFunction<T, T>
-{
-  /**
-   * The last value returned by the function
-   */
-  private T m_lastValue;
+public class CumulativeFunction<T> extends UnaryFunction<T, T> {
+    /**
+     * The last value returned by the function
+     */
+    private T m_lastValue;
 
-  /**
-   * The start value of the function
-   */
+    /**
+     * The start value of the function
+     */
 
-  private T m_startValue;
+    private T m_startValue;
 
-  /**
-   * The stateless binary function to apply on each call
-   */
-  private BinaryFunction<T, T, T> m_function;
+    /**
+     * The stateless binary function to apply on each call
+     */
+    private BinaryFunction<T, T, T> m_function;
 
-  /**
-   * Instantiates a new cumulative function
-   * @param function The function to cumulate
-   */
-  public CumulativeFunction(BinaryFunction<T, T, T> function)
-  {
-    this(function, function.getStartValue());
-  }
-
-  /**
-   * Instantiates a new cumulative function with a start value
-   * @param function the function to cumulate
-   * @param startValue the start value of the function
-   */
-  public CumulativeFunction(BinaryFunction<T, T, T> function, T startValue) {
-    super(function.getInputTypeLeft(), function.getOutputType());
-    m_function = function;
-    m_startValue = startValue;
-    m_lastValue = startValue;
-  }
-
-  @Override
-  public T getValue(T x)
-  {
-    if (m_lastValue == null)
-    {
-      // If the function did not provide a start value, use the
-      // first given argument as the start value
-      m_lastValue = x;
-      return x;
+    /**
+     * Instantiates a new cumulative function
+     *
+     * @param function The function to cumulate
+     */
+    public CumulativeFunction(BinaryFunction<T, T, T> function) {
+        // If no start value is provided, we use the start value of the function that gived to the CumulativeFunction constructor
+        this(function, function.getStartValue());
     }
-    T value = m_function.getValue(m_lastValue, x);
-    m_lastValue = value;
-    return value;
-  }
 
-  @Override
-  public void reset()
-  {
-    m_lastValue = this.m_startValue;
-  }
-
-  @Override
-  public CumulativeFunction<T> duplicate(boolean with_state)
-  {
-    CumulativeFunction<T> cf = new CumulativeFunction<T>(m_function.duplicate(with_state));
-    if (with_state)
-    {
-      cf.m_lastValue = m_lastValue;
+    /**
+     * Instantiates a new cumulative function with a start value
+     *
+     * @param function   the function to cumulate
+     * @param startValue the start value of the function
+     */
+    public CumulativeFunction(BinaryFunction<T, T, T> function, T startValue) {
+        super(function.getInputTypeLeft(), function.getOutputType());
+        m_function = function;
+        // We store the start value in case of reset
+        m_startValue = startValue;
+        m_lastValue = startValue;
     }
-    return cf;
-  }
 
-  /**
-   * @since 0.10.2
-   */
-  @Override
-  public Object printState()
-  {
-    List<Object> list = new ArrayList<Object>(2);
-    list.add(m_function);
-    list.add(m_lastValue);
-    return list;
-  }
+    @Override
+    public T getValue(T x) {
+        if (m_lastValue == null) {
+            // If the function did not provide a start value, use the
+            // first given argument as the start value
+            m_lastValue = x;
+            return x;
+        }
+        T value = m_function.getValue(m_lastValue, x);
+        m_lastValue = value;
+        return value;
+    }
 
-  /**
-   * @since 0.10.2
-   */
-  @SuppressWarnings("unchecked")
-  public CumulativeFunction<T> readState(Object o)
-  {
-    List<Object> list = (List<Object>) o;
-    BinaryFunction<T,T,T> func = (BinaryFunction<T,T,T>) list.get(0);
-    CumulativeFunction<T> cf = new CumulativeFunction<T>(func);
-    cf.m_lastValue = (T) list.get(1);
-    return cf;
-  }
+    @Override
+    public void reset() {
+        m_lastValue = this.m_startValue;
+    }
 
-  /**
-   * @since 0.11
-   * @return The last value
-   */
-  /*@ pure @*/ public T getLastValue()
-  {
-    return m_lastValue;
-  }
+    @Override
+    public CumulativeFunction<T> duplicate(boolean with_state) {
+        CumulativeFunction<T> cf = new CumulativeFunction<T>(m_function.duplicate(with_state));
+        if (with_state) {
+            cf.m_lastValue = m_lastValue;
+        }
+        return cf;
+    }
+
+    /**
+     * @since 0.10.2
+     */
+    @Override
+    public Object printState() {
+        List<Object> list = new ArrayList<Object>(2);
+        list.add(m_function);
+        list.add(m_lastValue);
+        return list;
+    }
+
+    /**
+     * @since 0.10.2
+     */
+    @SuppressWarnings("unchecked")
+    public CumulativeFunction<T> readState(Object o) {
+        List<Object> list = (List<Object>) o;
+        BinaryFunction<T, T, T> func = (BinaryFunction<T, T, T>) list.get(0);
+        CumulativeFunction<T> cf = new CumulativeFunction<T>(func);
+        cf.m_lastValue = (T) list.get(1);
+        return cf;
+    }
+
+    /**
+     * @return The last value
+     * @since 0.11
+     */
+    /*@ pure @*/
+    public T getLastValue() {
+        return m_lastValue;
+    }
 
 }


### PR DESCRIPTION
Actualy, when we want to create a Cumulate with a CumulativeFunction inside that process a sum of number, it's not possible to indicate that we want to start at "1", it only take the first input stream.
This modification allow in the constructor to indicate a start value and still allow to use the basic method.
So now we can use it like this :
```java
Cumulate mySumWithStartValue= new Cumulate(new CumulateFunction<Number>(Numbers.addition, 1));
```
And still like that : 
```java
Cumulate myBasicSum = new Cumulate(new CumulateFunction<Number>(Numbers.addition));
```